### PR TITLE
Confrontation list models

### DIFF
--- a/app/src/main/java/br/com/mob1st/bet/core/firebase/CrashlyticsTool.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/firebase/CrashlyticsTool.kt
@@ -2,7 +2,7 @@ package br.com.mob1st.bet.core.firebase
 
 import br.com.mob1st.bet.core.logs.CrashReportingTool
 import br.com.mob1st.bet.core.logs.getPropertiesTree
-import br.com.mob1st.bet.core.utils.toFormat
+import br.com.mob1st.bet.core.utils.extensions.toFormat
 import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import java.util.Date

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/ActivityExtensions.kt
@@ -1,4 +1,4 @@
-package br.com.mob1st.bet.core.utils
+package br.com.mob1st.bet.core.utils.extensions
 
 import android.app.Activity
 import android.content.Intent

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/DateExtensions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/DateExtensions.kt
@@ -1,4 +1,4 @@
-package br.com.mob1st.bet.core.utils
+package br.com.mob1st.bet.core.utils.extensions
 
 import java.text.SimpleDateFormat
 import java.util.Date

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/ListExtensions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/extensions/ListExtensions.kt
@@ -1,4 +1,4 @@
-package br.com.mob1st.bet.core.utils
+package br.com.mob1st.bet.core.utils.extensions
 
 /**
  * Calls the given [ifBlock] if there are itens in the list

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Duo.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Duo.kt
@@ -1,0 +1,6 @@
+package br.com.mob1st.bet.core.utils.objects
+
+/**
+ * A pair of something that has the same type in common
+ */
+typealias Duo<T> = Pair<T, T>

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Node.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Node.kt
@@ -1,0 +1,9 @@
+package br.com.mob1st.bet.core.utils.objects
+
+/**
+ * A tree node that indicates the [current] value in the tree and the next possible [paths]
+ */
+data class Node<T>(
+    val current: T,
+    val paths: List<Node<T>>,
+)

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Bet.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Bet.kt
@@ -1,0 +1,23 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+/**
+ * Risk a sum of money or valued item against someone else's on the basis of the outcome of an
+ * unpredictable event such as a football match.
+ *
+ * The [subject] under bet has some probability to happens, typically called as [odds]
+ */
+data class Bet<T>(
+    val odds: Odds,
+    val subject: T
+)
+
+/**
+ * There are many possible types of odds.
+ * Here you can find some of them
+ */
+sealed class Odds {
+    abstract val value: Double
+
+    data class European(override val value: Double) : Odds()
+    data class American(override val value: Double) : Odds()
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
@@ -1,0 +1,21 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.utils.objects.Node
+import java.util.Date
+
+/**
+ * A confrontation provides bets
+ */
+data class Confrontation(
+    val startAt: Date,
+    val expectedDuration: Long,
+    val status: CompetitionStatus,
+    val contest: Node<Contest>
+)
+
+enum class CompetitionStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    FINISHED,
+    CANCELED
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
@@ -8,25 +8,9 @@ import br.com.mob1st.bet.core.utils.objects.Duo
 sealed interface Contest
 
 /**
- * When two contenders face each other in a 1x1 confrontation, we have a Duel
- */
-interface Duel<T> {
-    val contender1: Bet<T>
-    val contender2: Bet<T>
-    val draw: Bet<Nothing>
-}
-
-/**
- * When many possibilities can happen during a confrontation,
- */
-interface MultiChoice<T> {
-    val contenders: List<Bet<T>>
-}
-
-/**
  * A match between two teams
  */
-data class FootballMatch(
+data class MatchWinner(
     override val contender1: Bet<Team>,
     override val contender2: Bet<Team>,
     override val draw: Bet<Nothing>

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
@@ -1,0 +1,40 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.utils.objects.Duo
+
+/**
+ * A contest is a predefined structure to allow the user to bet in something
+ */
+sealed interface Contest
+
+/**
+ * When two contenders face each other in a 1x1 confrontation, we have a Duel
+ */
+interface Duel<T> {
+    val contender1: Bet<T>
+    val contender2: Bet<T>
+    val draw: Bet<Nothing>
+}
+
+/**
+ * When many possibilities can happen during a confrontation,
+ */
+interface MultiChoice<T> {
+    val contenders: List<Bet<T>>
+}
+
+/**
+ * A match between two teams
+ */
+data class FootballMatch(
+    override val contender1: Bet<Team>,
+    override val contender2: Bet<Team>,
+    override val draw: Bet<Nothing>
+) : Contest, Duel<Team>
+
+/**
+ * The available scores of a Contest
+ */
+data class IntScores(
+    override val contenders: List<Bet<Duo<Int>>>,
+) : Contest, MultiChoice<Duo<Int>>

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
@@ -1,0 +1,40 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+
+interface BetSelector<T> {
+    fun select(index: T): Bet<*>
+}
+
+/**
+ * When two contenders face each other in a 1x1 confrontation, we have a Duel
+ */
+interface Duel<T> : BetSelector<Duel.Selection>{
+    val contender1: Bet<T>
+    val contender2: Bet<T>
+    val draw: Bet<Nothing>
+
+    enum class Selection {
+        CONTENDER_1,
+        CONTENDER_2,
+        DRAW
+    }
+
+    override fun select(index: Selection): Bet<*> {
+        return when(index) {
+            Selection.CONTENDER_1 -> contender1
+            Selection.CONTENDER_2 -> contender2
+            Selection.DRAW -> draw
+        }
+    }
+}
+
+/**
+ * When many possibilities can happen during a confrontation,
+ */
+interface MultiChoice<T> : BetSelector<Int> {
+    val contenders: List<Bet<T>>
+
+    override fun select(index: Int): Bet<*> {
+        return contenders[index]
+    }
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Team.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Team.kt
@@ -1,0 +1,9 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.localization.LocalizedText
+
+data class Team(
+    val id: String,
+    val name: LocalizedText,
+    val logo: String
+)

--- a/app/src/main/java/br/com/mob1st/bet/features/home/HomeActivity.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/home/HomeActivity.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import br.com.mob1st.bet.core.ui.compose.setThemedContent
-import br.com.mob1st.bet.core.utils.getParcelableNotNull
+import br.com.mob1st.bet.core.utils.extensions.getParcelableNotNull
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
 
 class HomeActivity : ComponentActivity() {

--- a/app/src/main/java/br/com/mob1st/bet/features/launch/presentation/LauncherActivity.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/launch/presentation/LauncherActivity.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.Composable
 import br.com.mob1st.bet.core.ui.compose.setThemedContent
 import br.com.mob1st.bet.core.ui.ds.molecule.SystemBarProperties
 import br.com.mob1st.bet.core.ui.ds.molecule.SystemBars
-import br.com.mob1st.bet.core.utils.intent
-import br.com.mob1st.bet.core.utils.start
+import br.com.mob1st.bet.core.utils.extensions.intent
+import br.com.mob1st.bet.core.utils.extensions.start
 import br.com.mob1st.bet.features.home.HomeActivity
 import br.com.mob1st.bet.features.home.HomeActivity.Companion.put
 


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
We have plans to allow many different types of bets for many different types of sports and competitions.
Currently we only have support for the Football World Cup, but the structure of the app can be prepared for more.
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
Some important definitions for this models are the Confrontation, Contest and Bet

A **Confrontation** is something that will happen on a specific date and the user will have the possibility to bet. As an example imagine a football match where two teams will confront each other.

A **Contest** is a structure to organize the possible bets inside a Confrontation. In a football match, the user can have the options to define the winner, the score, the players that score the goals, etc... This organization is defined by the Contests of the football match

A **Bet** is one of the possibilities of something happening inside a Contest. It defines the odds when team A defeats team B in a football match, for example.