### PR TITLE
Confrontations list structure

### DIFF
--- a/app/src/main/java/br/com/mob1st/bet/core/firebase/FirestoreExtensions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/firebase/FirestoreExtensions.kt
@@ -15,6 +15,30 @@ inline fun <reified T> DocumentSnapshot.getNestedObject(fieldName: String): Map<
     } as Map<String, T>
 }
 
+/**
+ * Get a nested field in a map structure
+ *
+ * Useful to work with Firestore nested objects
+ */
+@Suppress("UNCHECKED_CAST")
+fun Map<String, *>.getNestedMap(fieldName: String): Map<String, Any> {
+    return checkNotNull(get(fieldName)) {
+        fieldMessage(fieldName)
+    } as Map<String, Any>
+}
+
+/**
+ * Get a list field in a map structure
+ *
+ * Useful to work with Firestore nested arrays
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> Map<String, *>.getNestedList(fieldName: String): List<T> {
+    return checkNotNull(get(fieldName)) {
+        fieldMessage(fieldName)
+    } as List<T>
+}
+
 fun DocumentSnapshot.getDateNotNull(fieldName: String): Date {
     return checkNotNull(getDate(fieldName)) {
         fieldMessage(fieldName)

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
@@ -3,6 +3,7 @@ package br.com.mob1st.bet.features.competitions.data
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
 import br.com.mob1st.bet.features.competitions.domain.Competition
 import br.com.mob1st.bet.features.competitions.domain.CompetitionRepository
+import br.com.mob1st.bet.features.competitions.domain.Confrontation
 import br.com.mob1st.bet.features.competitions.domain.GetDefaultCompetitionException
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
@@ -19,6 +20,10 @@ class CompetitionRepositoryImpl(
         runCatching {
             competitionCollection.getDefault()
         }.getOrElse { throw GetDefaultCompetitionException(it) }
+    }
+
+    override suspend fun getConfrontationsBy(competitionId: String): List<Confrontation> = withContext(io){
+        TODO("Not yet implemented")
     }
 
 }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
@@ -4,6 +4,7 @@ import br.com.mob1st.bet.core.coroutines.DispatcherProvider
 import br.com.mob1st.bet.features.competitions.domain.Competition
 import br.com.mob1st.bet.features.competitions.domain.CompetitionRepository
 import br.com.mob1st.bet.features.competitions.domain.Confrontation
+import br.com.mob1st.bet.features.competitions.domain.GetConfrontationListException
 import br.com.mob1st.bet.features.competitions.domain.GetDefaultCompetitionException
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
@@ -23,7 +24,9 @@ class CompetitionRepositoryImpl(
     }
 
     override suspend fun getConfrontationsBy(competitionId: String): List<Confrontation> = withContext(io){
-        TODO("Not yet implemented")
+        runCatching {
+            competitionCollection.getConfrontationsById(competitionId)
+        }.getOrElse { throw GetConfrontationListException(competitionId, it) }
     }
 
 }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/ContestMapper.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/ContestMapper.kt
@@ -1,0 +1,64 @@
+package br.com.mob1st.bet.features.competitions.data
+
+import br.com.mob1st.bet.core.utils.objects.Node
+import br.com.mob1st.bet.features.competitions.domain.Bet
+import br.com.mob1st.bet.features.competitions.domain.CompetitionType
+import br.com.mob1st.bet.features.competitions.domain.Contest
+import br.com.mob1st.bet.features.competitions.domain.IntScores
+import br.com.mob1st.bet.features.competitions.domain.MatchWinner
+import br.com.mob1st.bet.features.competitions.domain.Odds
+import br.com.mob1st.bet.features.competitions.domain.Team
+
+/**
+ * receives a contest in key-value structure and returns the correspoding [Contest] instance based
+ * on the [CompetitionType] provided to [ContestMapFactory]
+ */
+typealias FirebaseContestMapper = (contest: Map<String, Any>) -> Node<Contest>
+
+object ContestMapFactory {
+
+    operator fun get(competitionType: CompetitionType): FirebaseContestMapper {
+        return when (competitionType) {
+            CompetitionType.FOOTBALL -> { nodeBuilder }
+        }
+    }
+}
+
+private val nodeBuilder: FirebaseContestMapper = { data: Map<String, Any> ->
+    Node(
+        current = matchWinner(data),
+        paths = listOf(
+            Node(
+                current = matchScore(data),
+                paths = emptyList()
+            )
+        )
+    )
+}
+
+private val matchWinner = { current: Map<String, Any> ->
+     MatchWinner(
+         contender1 = Bet(
+             odds = Odds.American(0.0),
+             subject = Team("", emptyMap(), "")
+         ),
+         contender2 = Bet(
+             odds = Odds.American(0.0),
+             subject = Team("", emptyMap(), "")
+         ),
+         draw = Bet(
+             odds = Odds.American(0.0),
+             subject = Unit
+         )
+     )
+}
+
+private val bet = { bet: Map<String, Any> ->
+
+}
+
+private val matchScore = { paths: Map<String, Any> ->
+    IntScores(
+        contenders = emptyList()
+    )
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/ContestMapper.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/ContestMapper.kt
@@ -14,7 +14,6 @@ import br.com.mob1st.bet.features.competitions.domain.Team
  * on the [CompetitionType] provided to [ContestMapFactory]
  */
 typealias FirebaseContestMapper = (contest: Map<String, Any>) -> Node<Contest>
-
 object ContestMapFactory {
 
     operator fun get(competitionType: CompetitionType): FirebaseContestMapper {
@@ -36,6 +35,7 @@ private val nodeBuilder: FirebaseContestMapper = { data: Map<String, Any> ->
     )
 }
 
+// TODO figure out how to avoid map property by property in firebase
 private val matchWinner = { current: Map<String, Any> ->
      MatchWinner(
          contender1 = Bet(

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/CompetitionRepository.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/CompetitionRepository.kt
@@ -11,4 +11,9 @@ interface CompetitionRepository {
      */
     suspend fun getDefaultCompetition(): Competition
 
+    /**
+     * Returns a list of the next confrontations related to the given [competitionId]
+     */
+    suspend fun getConfrontationsBy(competitionId: String): List<Confrontation>
+
 }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
@@ -7,13 +7,15 @@ import java.util.Date
  * A confrontation provides bets
  */
 data class Confrontation(
+    val id: String,
     val startAt: Date,
+    val allowBetsUntil: Date,
     val expectedDuration: Long,
-    val status: CompetitionStatus,
+    val status: ConfrontationStatus,
     val contest: Node<Contest>
 )
 
-enum class CompetitionStatus {
+enum class ConfrontationStatus {
     NOT_STARTED,
     IN_PROGRESS,
     FINISHED,

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
@@ -13,7 +13,7 @@ sealed interface Contest
 data class MatchWinner(
     override val contender1: Bet<Team>,
     override val contender2: Bet<Team>,
-    override val draw: Bet<Nothing>
+    override val draw: Bet<Unit>
 ) : Contest, Duel<Team>
 
 /**

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
@@ -11,7 +11,7 @@ interface BetSelector<T> {
 interface Duel<T> : BetSelector<Duel.Selection>{
     val contender1: Bet<T>
     val contender2: Bet<T>
-    val draw: Bet<Nothing>
+    val draw: Bet<Unit>
 
     enum class Selection {
         CONTENDER_1,

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Exceptions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Exceptions.kt
@@ -1,5 +1,17 @@
 package br.com.mob1st.bet.features.competitions.domain
 
+import br.com.mob1st.bet.core.logs.Debuggable
+
 class GetDefaultCompetitionException(
     cause: Throwable
 ) : Exception("unable to get the default competition", cause)
+
+class GetConfrontationListException(
+    private val id: String,
+    cause: Throwable
+) : Exception("unable to get the competition id $id", cause), Debuggable {
+    override fun logProperties(): Map<String, Any> {
+        return mapOf("competitionId" to id)
+    }
+
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Team.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Team.kt
@@ -1,9 +1,15 @@
 package br.com.mob1st.bet.features.competitions.domain
 
+import androidx.annotation.Keep
 import br.com.mob1st.bet.core.localization.LocalizedText
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
+@Keep
 data class Team(
+    @SerialName("ref")
     val id: String,
     val name: LocalizedText,
-    val logo: String
+    val url: String
 )

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/CompetitionsTabScreen.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/CompetitionsTabScreen.kt
@@ -1,21 +1,49 @@
 package br.com.mob1st.bet.features.competitions.presentation
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import br.com.mob1st.bet.core.localization.getText
 import br.com.mob1st.bet.core.ui.ds.InfoTemplate
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CompetitionsTabScreen(entry: CompetitionEntry) {
+    val viewModel = koinViewModel<ConfrontationListViewModel> {
+        parametersOf(entry)
+    }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val name = state.data.entry.name
+    val count = state.data.confrontations.size
     val context = LocalContext.current
-    InfoTemplate(
-        icon = { Icon(imageVector = Icons.Default.Home, contentDescription = "competition") },
-        title = { Text("Aba de competições") },
-        description = { Text("Em breve todos os jogos da ${context.getText(entry.name)} aqui") },
-    )
+    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+        Crossfade(targetState = state.loading) { target ->
+            if (target) {
+                CircularProgressIndicator()
+            } else {
+                InfoTemplate(
+                    icon = { Icon(imageVector = Icons.Default.Home, contentDescription = "competition") },
+                    title = { Text("Aba de competições") },
+                    description = { Text("Em breve todos os jogos da ${context.getText(name)} aqui com $count partidas") },
+                )
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
@@ -1,0 +1,38 @@
+package br.com.mob1st.bet.features.competitions.presentation
+
+import arrow.optics.optics
+import br.com.mob1st.bet.core.ui.state.AsyncState
+import br.com.mob1st.bet.core.ui.state.StateViewModel
+import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
+import br.com.mob1st.bet.features.competitions.domain.CompetitionRepository
+import br.com.mob1st.bet.features.competitions.domain.Confrontation
+import org.koin.android.annotation.KoinViewModel
+
+@optics
+data class ConfrontationData(
+    val entry: CompetitionEntry,
+    val confrontations: List<Confrontation> = emptyList(),
+) {
+    companion object
+}
+
+@KoinViewModel
+class ConfrontationListViewModel(
+    entry: CompetitionEntry,
+    private val repository: CompetitionRepository
+) : StateViewModel<ConfrontationData, Nothing>(AsyncState(data = ConfrontationData(entry), loading = true)){
+
+    init {
+        setState {
+            val confrontations = repository.getConfrontationsBy(it.data.entry.id)
+            logger.d("fetch ${confrontations.size} confrontations")
+            it.data(
+                ConfrontationData.confrontations.set(it.data, confrontations)
+            )
+        }
+    }
+
+    override fun fromUi(uiEvent: Nothing) {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
The main files to fetch confrontations of a competition
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
I'm trying to figure out how to serialize the Firestore response avoiding boillerplate code, because currently we need to map property by property and it's painful.
After that I will be able to list the competitions on UI properly
