### PR TITLE
App scope

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".BetApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/br/com/mob1st/bet/BetApp.kt
+++ b/app/src/main/java/br/com/mob1st/bet/BetApp.kt
@@ -1,0 +1,20 @@
+package br.com.mob1st.bet
+
+import android.app.Application
+import br.com.mob1st.bet.core.coroutines.AppScopeProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+
+class BetApp : Application(), AppScopeProvider {
+
+    private var _appScope: CoroutineScope = MainScope()
+    override val appScope: CoroutineScope get() = _appScope
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        _appScope.cancel("onLowMemory called by the BetApp")
+        _appScope = MainScope()
+    }
+
+}

--- a/app/src/main/java/br/com/mob1st/bet/core/coroutines/AppScopeProvider.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/coroutines/AppScopeProvider.kt
@@ -1,0 +1,17 @@
+package br.com.mob1st.bet.core.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Make the Application class implements this interface to provide the app coroutine scope
+ * It can be useful for cases where suspend functions should be triggered without attach it to the
+ * lifecycle of UIs or ViewModels
+ */
+interface AppScopeProvider {
+
+    /**
+     * The coroutine scope attached to the app lifecycle
+     */
+    val appScope: CoroutineScope
+
+}

--- a/app/src/main/java/br/com/mob1st/bet/di/CoroutinesModule.kt
+++ b/app/src/main/java/br/com/mob1st/bet/di/CoroutinesModule.kt
@@ -1,10 +1,11 @@
 package br.com.mob1st.bet.di
 
+import br.com.mob1st.bet.core.coroutines.AppScopeProvider
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
-import kotlinx.coroutines.Dispatchers
-import org.koin.core.qualifier.named
+import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
 val coroutinesModule = module {
     single<DispatcherProvider> { DispatcherProvider }
+    single { androidApplication() as AppScopeProvider }
 }


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
All our API requests are attached to the lifecycle of the ViewModel because we use the `viewModelScope` for that. It means that, when the ViewModel is cleared (eg. when the user closes a screen), all ongoing coroutines created by this scope is canceled.
In the majority of the cases this is the expected behaviour, but eventually we need to keep the requests alive even if the user leaves the screen.
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
I created a CoroutineScope attached to the application class lifecycle, so now we can make the some API requests persists even after the ui is closed.
It will be useful for the guess creation feature