### PR TITLE
Suspend runcatching

### DIFF
--- a/app/src/main/java/br/com/mob1st/bet/core/ui/state/StateViewModel.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/ui/state/StateViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import kotlin.Exception
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * The project's base ViewModel, used to handle the asynchronous state changes in the UI.
@@ -115,6 +116,8 @@ abstract class StateViewModel<Data, UiEvent>(initialState: AsyncState<Data>) : V
         viewModelState.update { current ->
             try {
                 block(current)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.e("setState have failed", e)
                 current.failure()
@@ -123,7 +126,7 @@ abstract class StateViewModel<Data, UiEvent>(initialState: AsyncState<Data>) : V
     }
 
     /**
-     * Turn on the loading
+     * Turn on the loading on
      */
     protected fun loading() = viewModelState.update {
         it.loading()

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/functions/Result.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/functions/Result.kt
@@ -1,0 +1,21 @@
+package br.com.mob1st.bet.core.utils.functions
+
+import timber.log.Timber
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Attempts [block], returning a successful [Result] if it succeeds, otherwise a [Result.Failure]
+ * taking care not to break structured concurrency
+ */
+suspend fun <T> suspendRunCatching(block: suspend () -> T): Result<T> = try {
+    Result.success(block())
+} catch (cancellationException: CancellationException) {
+    throw cancellationException
+} catch (exception: Exception) {
+    Timber.i(
+        "suspendRunCatching",
+        "Failed to evaluate a suspendRunCatchingBlock. Returning failure Result",
+        exception
+    )
+    Result.failure(exception)
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/CompetitionRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package br.com.mob1st.bet.features.competitions.data
 
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
+import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
 import br.com.mob1st.bet.features.competitions.domain.Competition
 import br.com.mob1st.bet.features.competitions.domain.CompetitionRepository
 import br.com.mob1st.bet.features.competitions.domain.Confrontation
@@ -18,13 +19,13 @@ class CompetitionRepositoryImpl(
     private val io get() = provider.io
 
     override suspend fun getDefaultCompetition(): Competition = withContext(io){
-        runCatching {
+        suspendRunCatching {
             competitionCollection.getDefault()
         }.getOrElse { throw GetDefaultCompetitionException(it) }
     }
 
     override suspend fun getConfrontationsBy(competitionId: String): List<Confrontation> = withContext(io){
-        runCatching {
+        suspendRunCatching {
             competitionCollection.getConfrontationsById(competitionId)
         }.getOrElse { throw GetConfrontationListException(competitionId, it) }
     }

--- a/app/src/main/java/br/com/mob1st/bet/features/ff/FeatureFlagRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/ff/FeatureFlagRepositoryImpl.kt
@@ -3,6 +3,7 @@ package br.com.mob1st.bet.features.ff
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
 import br.com.mob1st.bet.core.firebase.awaitWithTimeout
 import br.com.mob1st.bet.core.logs.Logger
+import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.get
 import kotlinx.coroutines.TimeoutCancellationException
@@ -19,7 +20,7 @@ internal class FeatureFlagRepositoryImpl(
     private val io get() = provider.io
 
     override suspend fun sync(): Unit = withContext(io) {
-        runCatching {
+        suspendRunCatching {
             try {
                 remoteConfig.fetchAndActivate().awaitWithTimeout()
             } catch (e: TimeoutCancellationException) {

--- a/app/src/main/java/br/com/mob1st/bet/features/groups/data/GroupRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/groups/data/GroupRepositoryImpl.kt
@@ -5,6 +5,7 @@ Tu pode ver que nos imports não tem nada referenciando o firebase, porque o Gro
 ele do projeto
  */
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
+import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
 import br.com.mob1st.bet.features.groups.domain.CreateGroupException
 import br.com.mob1st.bet.features.groups.domain.Group
@@ -48,7 +49,7 @@ class GroupRepositoryImpl(
             memberCount = 1
         )
         val entry = group.toEntry()
-        runCatching {
+        suspendRunCatching {
             groupCollection.create(founder, group).let { entry }
         }.getOrElse {
             throw CreateGroupException(

--- a/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package br.com.mob1st.bet.features.profile.data
 
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
+import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
 import br.com.mob1st.bet.features.profile.domain.AnonymousSignInException
 import br.com.mob1st.bet.features.profile.domain.AuthStatus
@@ -30,7 +31,7 @@ internal class UserRepositoryImpl(
     }
 
     override suspend fun subscribe(entry: CompetitionEntry): Unit = withContext(io){
-        runCatching {
+        suspendRunCatching {
             val userId = checkNotNull(userAuth.get()?.id)
             userCollection.subscribe(
                 userId,
@@ -42,13 +43,13 @@ internal class UserRepositoryImpl(
     }
 
     override suspend fun get(): User {
-        return runCatching {
+        return suspendRunCatching {
             checkNotNull(userAuth.get())
         }.getOrElse { throw GetUserException(it) }
     }
 
     private suspend fun authUser(): User {
-        return runCatching {
+        return suspendRunCatching {
             userAuth.signInAnonymously()
         }.getOrElse {
             throw AnonymousSignInException(it)
@@ -64,7 +65,7 @@ internal class UserRepositoryImpl(
     }
 
     override suspend fun getFirstAvailableSubscription(): CompetitionEntry = withContext(io) {
-        runCatching {
+        suspendRunCatching {
             userCollection.getCompetitionEntry(checkNotNull(userAuth.getId()))
         }.getOrElse {
             throw GetUserFirstAvailableSubscription(it)


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
The coroutines throws a CancelationException when the coroutines are cancelled, which is expected and handled automatically by the coroutines API.
However, we are using `runCatching` to avoid crashes in the app when some request fails, and this method catches also the CancelationException, breaking the continuation of asynchronous operations, and it can make impossible for some coroutines to be closed
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->

I just create a function to let the CancelationException be rethrown, then the Coroutines api can cancel everything automatically.
[Here](https://github.com/Kotlin/kotlinx.coroutines/issues/1814) you can find more details about this implementation
