### PR TITLE
Create guess: modeling entities

### DIFF
--- a/app/src/main/java/br/com/mob1st/bet/core/logs/Debuggable.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/logs/Debuggable.kt
@@ -15,6 +15,6 @@ interface Debuggable {
      *
      * @return a map containing the keys and the values to be logged
      */
-    fun logProperties(): Map<String, Any>
+    fun logProperties(): Map<String, Any?>
 
 }

--- a/app/src/main/java/br/com/mob1st/bet/core/logs/ThrowableExtensions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/logs/ThrowableExtensions.kt
@@ -2,7 +2,7 @@ package br.com.mob1st.bet.core.logs
 
 fun Throwable.getPropertiesTree(
     thirdPartyExceptionDebugger: ThrowableDebugger<*>
-): Map<String, Any> {
+): Map<String, Any?> {
     val causeProperties = cause?.getPropertiesTree(thirdPartyExceptionDebugger).orEmpty()
     return if (this is Debuggable) {
         causeProperties + logProperties()

--- a/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Selector.kt
+++ b/app/src/main/java/br/com/mob1st/bet/core/utils/objects/Selector.kt
@@ -1,0 +1,8 @@
+package br.com.mob1st.bet.core.utils.objects
+
+/**
+ * An abstraction used when a selection of something can be done and return a value
+ */
+interface Selector<in Selection, out Result> {
+    fun select(selection: Selection): Result
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
@@ -1,0 +1,30 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.utils.objects.Duo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface Answer<T : Any> {
+    val weight: Int
+    val odds: Odds
+    val selected: T
+
+    fun points() = odds * weight
+}
+
+@Serializable
+@SerialName("DuelWinner")
+data class DuelWinner(
+    override val weight: Int,
+    override val odds: Odds,
+    override val selected: Duel.Selection
+) : Answer<Duel.Selection>
+
+@Serializable
+@SerialName("FinalScore")
+data class FinalScore(
+    override val weight: Int,
+    override val odds: Odds,
+    override val selected: Duo<Int>,
+) : Answer<Duo<Int>>

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
@@ -4,15 +4,28 @@ import br.com.mob1st.bet.core.utils.objects.Duo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * A confrontation can have many possible answers, each of them have a different [weight] and
+ * different [odds].
+ *
+ * For example, in a football match the user can answer the winner, the score, the top scorer and m
+ * more. Each one of them is a different answer, containing different weights.
+ */
 @Serializable
 sealed interface Answer<T : Any> {
     val weight: Int
     val odds: Odds
     val selected: T
 
+    /**
+     * multiply the [odds] by the [weight]
+     */
     fun points() = odds * weight
 }
 
+/**
+ * A type of [Answer] that selects the winner of a [Duel]
+ */
 @Serializable
 @SerialName("DuelWinner")
 data class DuelWinner(
@@ -21,6 +34,9 @@ data class DuelWinner(
     override val selected: Duel.Selection
 ) : Answer<Duel.Selection>
 
+/**
+ * A type of [Answer] that selects the final score of a [Duel]
+ */
 @Serializable
 @SerialName("FinalScore")
 data class FinalScore(

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
@@ -1,0 +1,57 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.logs.Debuggable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Aggregates all answers for a specific contest, making possible to sum all of them in order to
+ * provide the possible total points the user can achieve in a guess
+ */
+@Serializable
+sealed interface AnswerAggregation : Debuggable {
+
+    /**
+     * all selected answers of the user
+     */
+    val answers: Set<Answer<*>>
+
+    /**
+     * the sum of all points of each answer in [answers]
+     */
+    fun totalPoints(): Long= answers.sumOf { it.points() }
+
+    /**
+     * Indicates if the selected answers available in [answers] are valid
+     */
+    fun isValid(): Boolean
+}
+
+/**
+ * It happens when a user tries to predict the result of some bet
+ */
+@Serializable
+@SerialName("WinnerAnswers")
+data class WinnerAnswers(
+    val winner: DuelWinner,
+    val score: FinalScore? = null,
+) : AnswerAggregation {
+    override val answers: Set<Answer<*>>
+        get() = score?.let { setOf(winner, it) } ?: setOf(winner)
+
+    override fun isValid(): Boolean {
+        return when {
+            score == null -> true
+            winner.selected == Duel.Selection.DRAW -> score.selected.first == score.selected.second
+            else -> score.selected.first != score.selected.second
+        }
+    }
+
+    override fun logProperties(): Map<String, Any?> {
+        return mapOf(
+            "winner" to winner.selected,
+            "score1" to score?.selected?.first,
+            "score2" to score?.selected?.second
+        )
+    }
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Bet.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Bet.kt
@@ -23,9 +23,14 @@ data class Bet<T>(
  */
 @Serializable
 @Keep
-sealed class Odds {
+sealed class Odds : Comparable<Odds> {
     abstract val value: Long
 
+    operator fun times(operator: Int) = value * operator
+
+    override fun compareTo(other: Odds): Int {
+        return value.compareTo(other.value)
+    }
 }
 
 @SerialName("EUROPEAN")

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Confrontation.kt
@@ -1,23 +1,19 @@
 package br.com.mob1st.bet.features.competitions.domain
 
-import arrow.optics.optics
 import br.com.mob1st.bet.core.utils.objects.Node
 import java.util.Date
 
 /**
  * A confrontation provides bets
  */
-@optics
 data class Confrontation(
     val id: String,
     val startAt: Date,
     val allowBetsUntil: Date,
     val expectedDuration: Long,
     val status: ConfrontationStatus,
-    val contest: Node<Contest>
-) {
-    companion object
-}
+    val contest: Node<Contest>,
+)
 
 enum class ConfrontationStatus {
     NOT_STARTED,

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/ContestSelector.kt
@@ -8,6 +8,9 @@ interface Duel<T> {
     val contender2: Bet<T>
     val draw: Bet<String>
 
+    /**
+     * The result of duel. In some cases [DRAW] is optional
+     */
     enum class Selection(val pathIndex: Int) {
         CONTENDER_1(0),
         CONTENDER_2(1),

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
@@ -1,9 +1,16 @@
 package br.com.mob1st.bet.features.competitions.domain
 
 import br.com.mob1st.bet.core.serialization.DateSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.Date
 
+/**
+ * The users will guess the results of confrontations to figure out who is the master of guessing.
+ *
+ * This is the guess the user can apply for the given [confrontation]. It has the [aggregation] of
+ * answers the user are enabled apply.
+ */
 @Serializable
 data class Guess(
     val id: String = "",
@@ -20,6 +27,9 @@ data class Guess(
      */
     fun betAllowed() = updatedAt <= confrontation.allowBetsUntil
 
+    /**
+     * Update the field [updatedAt] in the case this guess is not new (has id)
+     */
     fun update() = if (id.isEmpty()) {
         this
     } else copy(updatedAt = Date())
@@ -31,6 +41,7 @@ data class Guess(
 @Serializable
 data class ConfrontationForGuess(
     @Serializable
+    @SerialName("ref")
     val id: String,
     @Serializable(DateSerializer::class)
     val allowBetsUntil: Date

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
@@ -1,0 +1,37 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.serialization.DateSerializer
+import kotlinx.serialization.Serializable
+import java.util.Date
+
+@Serializable
+data class Guess(
+    val id: String = "",
+    @Serializable(DateSerializer::class)
+    val createdAt: Date = Date(),
+    @Serializable(DateSerializer::class)
+    val updatedAt: Date = createdAt,
+    val confrontation: ConfrontationForGuess,
+    val subscriptionId: String,
+    val aggregation: AnswerAggregation,
+) {
+    /**
+     * Indicates if the bet
+     */
+    fun betAllowed() = updatedAt <= confrontation.allowBetsUntil
+
+    fun update() = if (id.isEmpty()) {
+        this
+    } else copy(updatedAt = Date())
+}
+
+/**
+ * Nested object for guess
+ */
+@Serializable
+data class ConfrontationForGuess(
+    @Serializable
+    val id: String,
+    @Serializable(DateSerializer::class)
+    val allowBetsUntil: Date
+)


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
We need to enable the user to create guesses for confrontations. Each guess can have a predefined number of possible answers.
For example, in a football match the user could select the winner, the score, and more. In this case, the guess holds all this answers and more relate them to a confrontation.
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
This PR models the entities of the feature

#### Next steps
- Implement the usecase and repositories
- Enable the UI to trigger the usecase
