### PR TITLE
Fix/use guess repository

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessAnswerFactory.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessAnswerFactory.kt
@@ -1,4 +1,4 @@
-package br.com.mob1st.bet.features.profile.data
+package br.com.mob1st.bet.features.competitions.data
 
 import br.com.mob1st.bet.features.competitions.domain.AnswerAggregation
 import br.com.mob1st.bet.features.competitions.domain.DuelWinner
@@ -7,7 +7,7 @@ import br.com.mob1st.bet.features.competitions.domain.Odds
 import br.com.mob1st.bet.features.competitions.domain.WinnerAnswers
 
 /**
- * Creates
+ * Creates a strucure of answer in firestore depending on the given type
  */
 object GuessAnswerFactory {
 

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessCollection.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessCollection.kt
@@ -1,0 +1,54 @@
+package br.com.mob1st.bet.features.competitions.data
+
+import br.com.mob1st.bet.core.firebase.awaitWithTimeout
+import br.com.mob1st.bet.features.competitions.domain.ConfrontationForGuess
+import br.com.mob1st.bet.features.competitions.domain.Guess
+import br.com.mob1st.bet.features.profile.data.subscriptions
+import com.google.firebase.firestore.FirebaseFirestore
+import org.koin.core.annotation.Factory
+
+@Factory
+class GuessCollection(
+    private val firestore: FirebaseFirestore
+) {
+
+    suspend fun createGuess(
+        userId: String,
+        guess: Guess,
+    ) {
+        val confrontation = guess.confrontation
+
+        firestore.guesses
+            .document(guess.id)
+            .set(mapOf(
+                Guess::createdAt::name to guess.createdAt,
+                Guess::updatedAt::name to guess.updatedAt,
+                Guess::aggregation::name to GuessAnswerFactory.toMap(guess.aggregation),
+                Guess::confrontation::name to mapOf(
+                    "ref" to firestore
+                        .confrontations(confrontation.competitionId)
+                        .document(confrontation.id),
+                    ConfrontationForGuess::allowBetsUntil to guess.confrontation.allowBetsUntil
+                ),
+                "subscriptionRef" to mapOf(
+                    "ref" to firestore.subscriptions(userId)
+                )
+            ))
+            .awaitWithTimeout()
+    }
+
+    suspend fun updateGuess(
+        guess: Guess,
+    ) {
+        firestore.guesses
+            .document(guess.id)
+            .update(mapOf(
+                Guess::updatedAt.name to guess.updatedAt,
+                Guess::aggregation.name to GuessAnswerFactory.toMap(guess.aggregation)
+            ))
+            .awaitWithTimeout()
+    }
+
+}
+
+val FirebaseFirestore.guesses get() = collection("guesses")

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package br.com.mob1st.bet.features.competitions.data
+
+import br.com.mob1st.bet.core.coroutines.DispatcherProvider
+import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
+import br.com.mob1st.bet.features.competitions.domain.Guess
+import br.com.mob1st.bet.features.competitions.domain.GuessRepository
+import br.com.mob1st.bet.features.competitions.domain.PlaceGuessException
+import br.com.mob1st.bet.features.profile.domain.User
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Factory
+
+@Factory
+class GuessRepositoryImpl(
+    private val guessCollection: GuessCollection,
+    private val dispatcherProvider: DispatcherProvider,
+) : GuessRepository {
+
+    private val io get() = dispatcherProvider.io
+
+    override suspend fun placeGuess(user: User, guess: Guess) = withContext(io){
+        // uses the app scope to avoid block the user until the guess is placed
+        suspendRunCatching {
+            if (guess.id.isEmpty()) {
+                guessCollection.createGuess(
+                    userId = user.id,
+                    guess = guess,
+                )
+            } else {
+                guessCollection.updateGuess(
+                    guess = guess,
+                )
+            }
+        }.getOrElse {
+            throw PlaceGuessException(guess, it)
+        }
+    }
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
@@ -1,6 +1,7 @@
 package br.com.mob1st.bet.features.competitions.domain
 
 import br.com.mob1st.bet.core.serialization.DateSerializer
+import br.com.mob1st.bet.features.profile.data.Subscription
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.Date
@@ -14,6 +15,8 @@ import java.util.Date
 @Serializable
 data class Guess(
     val id: String = "",
+    @SerialName("subscriptionRef")
+    val subscriptionId: String,
     @Serializable(DateSerializer::class)
     val createdAt: Date = Date(),
     @Serializable(DateSerializer::class)

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/GuessRepository.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/GuessRepository.kt
@@ -1,0 +1,37 @@
+package br.com.mob1st.bet.features.competitions.domain
+
+import br.com.mob1st.bet.core.logs.Debuggable
+import br.com.mob1st.bet.features.profile.domain.User
+
+/**
+ * Manages CRUD operations on Guess entity and everything that depends on it to exists
+ */
+interface GuessRepository {
+
+    /**
+     * Place the given guess for logged user.
+     * If the id of the guess is empty, then a guess will be created, otherwise the guess will
+     * update the fields that can be updated
+     */
+    suspend fun placeGuess(
+        user: User,
+        guess: Guess,
+    )
+
+}
+
+class PlaceGuessException(
+    private val guess: Guess,
+    cause: Throwable
+) : Exception("unable to create a guess", cause), Debuggable {
+    override fun logProperties(): Map<String, Any?> {
+        return mapOf(
+            "subscription" to guess.subscriptionId,
+            "confrontation" to guess.confrontation.id,
+            "confrontationAllowBetsUntil" to guess.confrontation.allowBetsUntil,
+            "createdAt" to guess.createdAt,
+            "updatedAt" to guess.updatedAt,
+        ) + guess.aggregation.logProperties()
+    }
+
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessEvent.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessEvent.kt
@@ -7,7 +7,6 @@ import br.com.mob1st.bet.core.arrow.dateTimeIso
  * Triggered when the user places a guess
  */
 data class PlaceGuessEvent(
-    private val subscriptionId: String,
     private val guess: Guess
 ) : AnalyticsEvent {
     override val name: String
@@ -18,7 +17,7 @@ data class PlaceGuessEvent(
             "moment" to dateTimeIso.get(guess.updatedAt),
             "betAllowedUntil" to dateTimeIso.get(guess.confrontation.allowBetsUntil),
             "confrontationId" to guess.confrontation.id,
-            "subscriptionId" to subscriptionId
+            "subscriptionId" to guess.subscriptionId
         ) + guess.aggregation.logProperties()
     }
 

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
@@ -1,9 +1,14 @@
 package br.com.mob1st.bet.features.competitions.domain
 
 import br.com.mob1st.bet.core.analytics.AnalyticsTool
+import br.com.mob1st.bet.core.coroutines.AppScopeProvider
 import br.com.mob1st.bet.core.logs.Debuggable
 import br.com.mob1st.bet.core.logs.Logger
+import br.com.mob1st.bet.features.profile.domain.AuthStatus
+import br.com.mob1st.bet.features.profile.domain.LoggedOut
+import br.com.mob1st.bet.features.profile.domain.User
 import br.com.mob1st.bet.features.profile.domain.UserRepository
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.Factory
 
 /**
@@ -15,19 +20,37 @@ import org.koin.core.annotation.Factory
 @Factory
 class PlaceGuessUseCase(
     private val userRepository: UserRepository,
+    private val guessRepository: GuessRepository,
     private val analyticsTool: AnalyticsTool,
     private val logger: Logger,
+    private val appScopeProvider: AppScopeProvider,
 ) {
 
-    suspend operator fun invoke(
-        subscriptionId: String,
+    operator fun invoke(
         guess: Guess,
-    ): Guess {
-        val updatedGuess = guess.update()
-        requireAllowedGuess(updatedGuess)
-        requireValidAnswers(updatedGuess)
-        placeGuess(subscriptionId, updatedGuess)
-        return updatedGuess
+    ) {
+        // to don't suspend the UI and allow the user to bet fast, this use case uses the app scope
+        appScopeProvider.appScope.launch {
+            try {
+                val updatedGuess = guess.update()
+                val user = requireAuthentication()
+                requireAllowedGuess(updatedGuess)
+                requireValidAnswers(updatedGuess)
+                placeGuess(user, updatedGuess)
+            } catch (e: Exception) {
+                // once we don't make the user wait the response of this use case, we should catch
+                // the error and log it her
+                logger.e("error for placing guess", e)
+            }
+
+        }
+    }
+
+    private suspend fun requireAuthentication(): User {
+        if (userRepository.getAuthStatus() == LoggedOut) {
+            throw RequireAuthException()
+        }
+        return userRepository.get()
     }
 
     private fun requireAllowedGuess(guess: Guess) {
@@ -44,13 +67,13 @@ class PlaceGuessUseCase(
         }
     }
 
-    private suspend fun placeGuess(subscriptionId: String, guess: Guess) {
+    private suspend fun placeGuess(user: User, guess: Guess) {
         logger.i("creating guess")
-        userRepository.placeGuess(
-            subscriptionId = subscriptionId,
+        guessRepository.placeGuess(
+            user = user,
             guess = guess,
         )
-        analyticsTool.log(PlaceGuessEvent(subscriptionId, guess))
+        analyticsTool.log(PlaceGuessEvent(guess))
     }
 
 }
@@ -78,5 +101,6 @@ class InvalidScoreException(
     override fun logProperties(): Map<String, Any?> {
         return aggregation.logProperties()
     }
-
 }
+
+class RequireAuthException() : Exception("you need authetication to create a guess")

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
@@ -4,7 +4,6 @@ import br.com.mob1st.bet.core.analytics.AnalyticsTool
 import br.com.mob1st.bet.core.coroutines.AppScopeProvider
 import br.com.mob1st.bet.core.logs.Debuggable
 import br.com.mob1st.bet.core.logs.Logger
-import br.com.mob1st.bet.features.profile.domain.AuthStatus
 import br.com.mob1st.bet.features.profile.domain.LoggedOut
 import br.com.mob1st.bet.features.profile.domain.User
 import br.com.mob1st.bet.features.profile.domain.UserRepository

--- a/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserCollection.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserCollection.kt
@@ -3,10 +3,7 @@ package br.com.mob1st.bet.features.profile.data
 import br.com.mob1st.bet.core.firebase.asJson
 import br.com.mob1st.bet.core.firebase.awaitWithTimeout
 import br.com.mob1st.bet.features.competitions.data.competitions
-import br.com.mob1st.bet.features.competitions.data.confrontations
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
-import br.com.mob1st.bet.features.competitions.domain.ConfrontationForGuess
-import br.com.mob1st.bet.features.competitions.domain.Guess
 import br.com.mob1st.bet.features.profile.domain.User
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
@@ -66,44 +63,6 @@ class UserCollection(
         }
     }
 
-    suspend fun createGuess(
-        userId: String,
-        subscriptionId: String,
-        guess: Guess,
-    ) {
-        val confrontation = guess.confrontation
-        firestore.guesses(userId, subscriptionId)
-            .document(guess.id)
-        firestore.guesses(userId, subscriptionId)
-            .document(guess.id)
-            .set(mapOf(
-                Guess::createdAt::name to guess.createdAt,
-                Guess::updatedAt::name to guess.updatedAt,
-                Guess::aggregation::name to GuessAnswerFactory.toMap(guess.aggregation),
-                Guess::confrontation::name to mapOf(
-                    "ref" to firestore
-                        .confrontations(confrontation.competitionId)
-                        .document(confrontation.id),
-                    ConfrontationForGuess::allowBetsUntil to guess.confrontation.allowBetsUntil
-                ),
-            ))
-            .awaitWithTimeout()
-    }
-
-    suspend fun updateGuess(
-        userId: String,
-        subscriptionId: String,
-        guess: Guess,
-    ) {
-        firestore.guesses(userId, subscriptionId)
-            .document(guess.id)
-            .update(mapOf(
-                Guess::updatedAt.name to guess.updatedAt,
-                Guess::aggregation.name to GuessAnswerFactory.toMap(guess.aggregation)
-            ))
-            .awaitWithTimeout()
-    }
-
 }
 
 val FirebaseFirestore.users get() =
@@ -113,7 +72,4 @@ fun FirebaseFirestore.subscriptions(userId: String) =
 
 fun FirebaseFirestore.memberships(userId: String) =
     users.document(userId).collection("memberships")
-
-fun FirebaseFirestore.guesses(userId: String, subscriptionId: String) =
-    subscriptions(userId).document(subscriptionId).collection("guesses")
 

--- a/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/profile/data/UserRepositoryImpl.kt
@@ -1,22 +1,17 @@
 package br.com.mob1st.bet.features.profile.data
 
-import br.com.mob1st.bet.core.coroutines.AppScopeProvider
 import br.com.mob1st.bet.core.coroutines.DispatcherProvider
-import br.com.mob1st.bet.core.logs.Logger
 import br.com.mob1st.bet.core.utils.functions.suspendRunCatching
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
-import br.com.mob1st.bet.features.competitions.domain.Guess
 import br.com.mob1st.bet.features.profile.domain.AnonymousSignInException
 import br.com.mob1st.bet.features.profile.domain.AuthStatus
 import br.com.mob1st.bet.features.profile.domain.GetUserException
 import br.com.mob1st.bet.features.profile.domain.GetUserFirstAvailableSubscription
-import br.com.mob1st.bet.features.profile.domain.PlaceGuessException
 import br.com.mob1st.bet.features.profile.domain.User
 import br.com.mob1st.bet.features.profile.domain.UserAuth
 import br.com.mob1st.bet.features.profile.domain.UserCreationException
 import br.com.mob1st.bet.features.profile.domain.UserRepository
 import br.com.mob1st.bet.features.profile.domain.UserSubscriptionException
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 
@@ -25,8 +20,6 @@ internal class UserRepositoryImpl(
     private val userAuth: UserAuth,
     private val userCollection: UserCollection,
     private val dispatcherProvider: DispatcherProvider,
-    private val appScopeProvider: AppScopeProvider,
-    private val logger: Logger,
 ) : UserRepository {
 
     private val io get() = dispatcherProvider.io
@@ -77,32 +70,6 @@ internal class UserRepositoryImpl(
         }.getOrElse {
             throw GetUserFirstAvailableSubscription(it)
         }
-    }
-
-    override suspend fun placeGuess(subscriptionId: String, guess: Guess) {
-        // uses the app scope to avoid block the user until the guess is placed
-        appScopeProvider.appScope.launch(io) {
-            suspendRunCatching {
-                if (guess.id.isEmpty()) {
-                    userCollection.createGuess(
-                        userId = checkNotNull(userAuth.getId()),
-                        subscriptionId = subscriptionId,
-                        guess = guess,
-                    )
-                } else {
-                    userCollection.updateGuess(
-                        userId = checkNotNull(userAuth.getId()),
-                        subscriptionId = subscriptionId,
-                        guess = guess,
-                    )
-                }
-            }.getOrElse {
-                // avoid error propagation and log it here.
-                // since it's not an operation that blocks the user, we will not throw errors
-                val e = PlaceGuessException(subscriptionId, guess, it)
-                logger.e("error when placing the guess", e)
-            }
-        }.join()
     }
 
     override suspend fun getAuthStatus(): AuthStatus = userAuth.getAuthStatus()

--- a/app/src/main/java/br/com/mob1st/bet/features/profile/domain/Exceptions.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/profile/domain/Exceptions.kt
@@ -1,7 +1,6 @@
 package br.com.mob1st.bet.features.profile.domain
 
 import br.com.mob1st.bet.core.logs.Debuggable
-import br.com.mob1st.bet.features.competitions.domain.Guess
 
 class AnonymousSignInException(
     cause: Throwable,
@@ -33,19 +32,3 @@ class GetUserFirstAvailableSubscription(
 class GetUserException(
     cause: Throwable
 ) : Exception("unable to get the user. check if login was executed first", cause)
-
-class PlaceGuessException(
-    private val subscriptionId: String,
-    private val guess: Guess,
-    cause: Throwable
-) : Exception("unable to place the guess", cause), Debuggable {
-    override fun logProperties(): Map<String, Any?> {
-        return mapOf(
-            "subscriptionId" to subscriptionId,
-            "updatedAt" to guess.updatedAt,
-            "createdAt" to guess.createdAt,
-            "confrontationId" to guess.confrontation.id,
-            "confrontationAllowsUntil" to guess.confrontation.allowBetsUntil,
-        ) + guess.aggregation.logProperties()
-    }
-}

--- a/app/src/main/java/br/com/mob1st/bet/features/profile/domain/UserRepository.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/profile/domain/UserRepository.kt
@@ -1,7 +1,6 @@
 package br.com.mob1st.bet.features.profile.domain
 
 import br.com.mob1st.bet.features.competitions.domain.CompetitionEntry
-import br.com.mob1st.bet.features.competitions.domain.Guess
 import br.com.mob1st.bet.features.profile.data.Subscription
 
 /**
@@ -39,15 +38,5 @@ interface UserRepository {
      * Get the first available competition for the User to start the app
      */
     suspend fun getFirstAvailableSubscription(): Subscription
-
-    /**
-     * Place the given guess for logged user.
-     * If the id of the guess is empty, then a guess will be created, otherwise the guess will
-     * update the fields that can be updated
-     */
-    suspend fun placeGuess(
-        subscriptionId: String,
-        guess: Guess,
-    )
 
 }


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
When a confrontation ends, the server will update the results and calculate the points each user made in the day.
It will check all guesses made for that confrontations and check who had success in the guesses.
Because of that, the current structure is not the best option, because the guesses collections are inside the user collection (`users/USER_ID/subscription/SUBSCRIPTION_ID/guesses/`).

Ideally the `guesses` collection have to be a root collection (same level as user), so it will allow an easy query to the server
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
Once the Guess is now a root colection, the Guess entity is a strong entity, this means that it needs a dedicated repository to manage its CRUD operations. This PR apply the changes to make it possible