### PR TITLE
Create guess

### DIFF
--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessCollection.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessCollection.kt
@@ -17,23 +17,20 @@ class GuessCollection(
         guess: Guess,
     ) {
         val confrontation = guess.confrontation
-
+        val params = mapOf(
+            Guess::createdAt.name to guess.createdAt,
+            Guess::updatedAt.name to guess.updatedAt,
+            Guess::aggregation.name to GuessAnswerFactory.toMap(guess.aggregation),
+            Guess::confrontation.name to mapOf(
+                "ref" to firestore
+                    .confrontations(confrontation.competitionId)
+                    .document(confrontation.id),
+                ConfrontationForGuess::allowBetsUntil.name to guess.confrontation.allowBetsUntil
+            ),
+            "subscriptionRef" to firestore.subscriptions(userId).document(guess.subscriptionId)
+        )
         firestore.guesses
-            .document(guess.id)
-            .set(mapOf(
-                Guess::createdAt::name to guess.createdAt,
-                Guess::updatedAt::name to guess.updatedAt,
-                Guess::aggregation::name to GuessAnswerFactory.toMap(guess.aggregation),
-                Guess::confrontation::name to mapOf(
-                    "ref" to firestore
-                        .confrontations(confrontation.competitionId)
-                        .document(confrontation.id),
-                    ConfrontationForGuess::allowBetsUntil to guess.confrontation.allowBetsUntil
-                ),
-                "subscriptionRef" to mapOf(
-                    "ref" to firestore.subscriptions(userId)
-                )
-            ))
+            .add(params)
             .awaitWithTimeout()
     }
 

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessRepositoryImpl.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/data/GuessRepositoryImpl.kt
@@ -17,7 +17,7 @@ class GuessRepositoryImpl(
 
     private val io get() = dispatcherProvider.io
 
-    override suspend fun placeGuess(user: User, guess: Guess) = withContext(io){
+    override suspend fun placeGuess(user: User, guess: Guess) = withContext(io) {
         // uses the app scope to avoid block the user until the guess is placed
         suspendRunCatching {
             if (guess.id.isEmpty()) {

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Answer.kt
@@ -31,7 +31,7 @@ sealed interface Answer<T : Any> {
 data class DuelWinner(
     override val weight: Int,
     override val odds: Odds,
-    override val selected: Duel.Selection
+    override val selected: Duel.Selection,
 ) : Answer<Duel.Selection>
 
 /**

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
@@ -33,7 +33,7 @@ sealed interface AnswerAggregation : Debuggable {
 @Serializable
 @SerialName("WinnerAnswers")
 data class WinnerAnswers(
-    val winner: DuelWinner?,
+    val winner: DuelWinner,
     val score: FinalScore? = null,
 ) : AnswerAggregation {
     override val answers: Set<Answer<*>>
@@ -41,7 +41,6 @@ data class WinnerAnswers(
 
     override fun isValid(): Boolean {
         return when {
-            winner == null -> false
             score == null -> true
             winner.selected == Duel.Selection.DRAW -> score.selected.first == score.selected.second
             else -> score.selected.first != score.selected.second

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/AnswerAggregation.kt
@@ -33,14 +33,15 @@ sealed interface AnswerAggregation : Debuggable {
 @Serializable
 @SerialName("WinnerAnswers")
 data class WinnerAnswers(
-    val winner: DuelWinner,
+    val winner: DuelWinner?,
     val score: FinalScore? = null,
 ) : AnswerAggregation {
     override val answers: Set<Answer<*>>
-        get() = score?.let { setOf(winner, it) } ?: setOf(winner)
+        get() = setOfNotNull(winner, score)
 
     override fun isValid(): Boolean {
         return when {
+            winner == null -> false
             score == null -> true
             winner.selected == Duel.Selection.DRAW -> score.selected.first == score.selected.second
             else -> score.selected.first != score.selected.second
@@ -49,7 +50,7 @@ data class WinnerAnswers(
 
     override fun logProperties(): Map<String, Any?> {
         return mapOf(
-            "winner" to winner.selected,
+            "winner" to winner?.selected,
             "score1" to score?.selected?.first,
             "score2" to score?.selected?.second
         )

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Contest.kt
@@ -33,7 +33,7 @@ data class MatchWinner(
             odds = bet.odds,
             // todo find a way to customize it
             weight = 1,
-            selected = selection
+            selected = selection,
         )
     }
 }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/Guess.kt
@@ -1,10 +1,9 @@
 package br.com.mob1st.bet.features.competitions.domain
 
 import br.com.mob1st.bet.core.serialization.DateSerializer
-import br.com.mob1st.bet.features.profile.data.Subscription
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.util.*
 
 /**
  * The users will guess the results of confrontations to figure out who is the master of guessing.
@@ -43,10 +42,15 @@ data class Guess(
 @Serializable
 data class ConfrontationForGuess(
     @Serializable
-    @SerialName("ref")
     val competitionId: String,
     @Serializable
     val id: String,
     @Serializable(DateSerializer::class)
     val allowBetsUntil: Date
-)
+) {
+    constructor(competitionId: String, confrontation: Confrontation) : this(
+        id = confrontation.id,
+        allowBetsUntil = confrontation.allowBetsUntil,
+        competitionId = competitionId
+    )
+}

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
@@ -25,9 +25,7 @@ class PlaceGuessUseCase(
     private val appScopeProvider: AppScopeProvider,
 ) {
 
-    suspend operator fun invoke(
-        guess: Guess,
-    ) {
+    suspend operator fun invoke(guess: Guess) {
         // to don't suspend the UI and allow the user to bet fast, this use case uses the app scope
         appScopeProvider.appScope.launch {
             try {
@@ -53,7 +51,7 @@ class PlaceGuessUseCase(
 
     private fun requireAllowedGuess(guess: Guess) {
         logger.v("validating guess expiration")
-        if (guess.betAllowed()) {
+        if (!guess.betAllowed()) {
             throw ExpiredBetException(guess)
         }
     }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/domain/PlaceGuessUseCase.kt
@@ -25,7 +25,7 @@ class PlaceGuessUseCase(
     private val appScopeProvider: AppScopeProvider,
 ) {
 
-    operator fun invoke(
+    suspend operator fun invoke(
         guess: Guess,
     ) {
         // to don't suspend the UI and allow the user to bet fast, this use case uses the app scope
@@ -41,8 +41,7 @@ class PlaceGuessUseCase(
                 // the error and log it her
                 logger.e("error for placing guess", e)
             }
-
-        }
+        }.join()
     }
 
     private suspend fun requireAuthentication(): User {

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
@@ -8,13 +8,23 @@ import br.com.mob1st.bet.core.ui.state.FetchedData
 import br.com.mob1st.bet.core.ui.state.SimpleMessage
 import br.com.mob1st.bet.core.ui.state.StateViewModel
 import br.com.mob1st.bet.core.utils.objects.Duo
+import br.com.mob1st.bet.core.utils.objects.Node
+import br.com.mob1st.bet.features.competitions.domain.AnswerAggregation
 import br.com.mob1st.bet.features.competitions.domain.CompetitionRepository
 import br.com.mob1st.bet.features.competitions.domain.Confrontation
+import br.com.mob1st.bet.features.competitions.domain.ConfrontationForGuess
+import br.com.mob1st.bet.features.competitions.domain.Contest
 import br.com.mob1st.bet.features.competitions.domain.Duel
+import br.com.mob1st.bet.features.competitions.domain.Guess
+import br.com.mob1st.bet.features.competitions.domain.IntScores
+import br.com.mob1st.bet.features.competitions.domain.MatchWinner
+import br.com.mob1st.bet.features.competitions.domain.PlaceGuessUseCase
+import br.com.mob1st.bet.features.competitions.domain.WinnerAnswers
 import br.com.mob1st.bet.features.profile.data.Subscription
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.koin.android.annotation.KoinViewModel
 
@@ -48,7 +58,7 @@ data class ConfrontationData(
 sealed class ConfrontationUiEvent {
     data class TryAgain(val message: SimpleMessage) : ConfrontationUiEvent()
     data class SetSelection(val index: Int?) : ConfrontationUiEvent()
-    object GetNext : ConfrontationUiEvent()
+    data class GetNext(val input: ConfrontationInput) : ConfrontationUiEvent()
 }
 
 @Parcelize
@@ -66,11 +76,32 @@ data class ConfrontationInput(
         }
         return copy(winner = newSelected, score = score)
     }
+
+    fun toAnswers(
+        root: Node<Contest>
+    ): AnswerAggregation {
+
+        val winnerAnswer = winner?.let {
+            (root.current as MatchWinner).select(it)
+        }
+        val scoreAnswer = winnerAnswer?.let {
+            val path = root.paths[it.selected.pathIndex].current as IntScores
+            score?.let { score ->
+                path.select(score)
+            }
+
+        }
+        return WinnerAnswers(
+            winner = winnerAnswer,
+            score = scoreAnswer
+        )
+    }
 }
 
 @KoinViewModel
 class ConfrontationListViewModel(
     subscription: Subscription,
+    private val placeGuessUseCase: PlaceGuessUseCase,
     private val repository: CompetitionRepository,
     private val savedState: SavedStateHandle
 ) : StateViewModel<ConfrontationData, ConfrontationUiEvent>(ConfrontationData(subscription)){
@@ -90,7 +121,7 @@ class ConfrontationListViewModel(
         when (uiEvent) {
             is ConfrontationUiEvent.TryAgain -> tryAgain(uiEvent.message)
             is ConfrontationUiEvent.SetSelection -> savedState[SELECTED] = uiEvent.index
-            ConfrontationUiEvent.GetNext -> getNext()
+            is ConfrontationUiEvent.GetNext -> getNext(uiEvent.input)
         }
     }
 
@@ -109,8 +140,22 @@ class ConfrontationListViewModel(
         }
     }
 
-    private fun getNext() {
+    private fun getNext(confrontationInput: ConfrontationInput) {
         setData { current ->
+            if (confrontationInput.winner != null) {
+                viewModelScope.launch {
+                    val answers = confrontationInput.toAnswers(current.detail!!.contest)
+                    val guess = Guess(
+                        subscriptionId = current.subscription.id,
+                        aggregation = answers,
+                        confrontation = ConfrontationForGuess(
+                            confrontation = current.detail!!,
+                            competitionId = current.subscription.competition.id
+                        )
+                    )
+                    placeGuessUseCase(guess)
+                }
+            }
             if (current.hasNext) {
                 val selected = checkNotNull(current.selected) {
                     "If hasNext returns true so selected should be not null"

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ConfrontationListViewModel.kt
@@ -80,16 +80,11 @@ data class ConfrontationInput(
     fun toAnswers(
         root: Node<Contest>
     ): AnswerAggregation {
-
-        val winnerAnswer = winner?.let {
-            (root.current as MatchWinner).select(it)
-        }
-        val scoreAnswer = winnerAnswer?.let {
-            val path = root.paths[it.selected.pathIndex].current as IntScores
-            score?.let { score ->
-                path.select(score)
-            }
-
+        checkNotNull(winner)
+        val winnerAnswer = (root.current as MatchWinner).select(winner)
+        val path = root.paths[winnerAnswer.selected.pathIndex].current as IntScores
+        val scoreAnswer = score?.let { score ->
+            path.select(score)
         }
         return WinnerAnswers(
             winner = winnerAnswer,
@@ -160,10 +155,11 @@ class ConfrontationListViewModel(
                 val selected = checkNotNull(current.selected) {
                     "If hasNext returns true so selected should be not null"
                 }
-                ConfrontationData.selected.set(current, selected + 1)
+                //ConfrontationData.selected.set(current, selected + 1)
             } else {
-                ConfrontationData.hasFinished.set(current, true)
+                //ConfrontationData.hasFinished.set(current, true)
             }
+            current
         }
     }
 

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ContestSelection.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/ContestSelection.kt
@@ -3,10 +3,6 @@ package br.com.mob1st.bet.features.competitions.presentation
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import br.com.mob1st.bet.core.ui.ds.atoms.CompositionLocalGrid
 import br.com.mob1st.bet.core.utils.objects.Node
@@ -17,17 +13,16 @@ import br.com.mob1st.bet.features.competitions.domain.MatchWinner
 @Composable
 fun NodeComponent(
     root: Node<Contest>,
+    input: ConfrontationInput,
+    onInput: (ConfrontationInput) -> Unit
 ) {
     val matchWinner = root.current as MatchWinner
-    var input: ConfrontationInput by rememberSaveable {
-        mutableStateOf(ConfrontationInput())
-    }
 
     MatchWinnerComponent(
         matchWinner = matchWinner,
         selected = input.winner,
         onSelectScore = { newSelected ->
-            input = input.selectWinner(newSelected)
+            onInput(input.selectWinner(newSelected))
         },
     )
 
@@ -38,7 +33,7 @@ fun NodeComponent(
             scores = intScores,
             selected = input.score,
             onSelect = {
-                input = input.copy(score = it)
+                onInput(input.copy(score = it))
             }
         )
     }

--- a/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/MatchWinnerComponents.kt
+++ b/app/src/main/java/br/com/mob1st/bet/features/competitions/presentation/MatchWinnerComponents.kt
@@ -75,7 +75,6 @@ fun MatchWinnerComponent(
     selected: Duel.Selection? = null,
     onSelectScore: (Duel.Selection?) -> Unit
 ) {
-
     Column(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
#### The problem
<!-- 
describe here why do you need to apply this change. 
use this space to add a text description and/or link issues to this PR 
-->
We have to allow the user create a guess when the winner and the score are selected
#### The solution
<!-- 
describe here which solution you have tried. 
do you have some doubts about your implementation or some specific detail you need a attention during the review? Comment it here!
-->
This PR implements the guess creation, with some limitations:
- Update an existing guess is not supported yet, only guess creation
- The navigation after the guess creation is not working
- Custom scores are not supported
- Error messages are not supported 

These limitations will require some deep changes on backend side to change the structure of the data (see [this](https://github.com/mob1st/bet-functions/issues/7) issue for more details) to be fixed. 
First I need to implement it in the API then I can return to the Android app to finish this feature

Closes #32 